### PR TITLE
Payload Validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![](https://img.shields.io/badge/version-1.1.0-green.svg)
+![](https://img.shields.io/badge/version-1.2.0-green.svg)
 [![Build & Test](https://github.com/aloosley/persistable/actions/workflows/python-build.yml/badge.svg)](https://github.com/aloosley/persistable/actions/workflows/python-build.yml)
 [![contributions welcome](https://img.shields.io/badge/contributions-welcome-brightgreen.svg?style=flat)](https://github.com/dwyl/esta/issues)
 

--- a/persistable/__init__.py
+++ b/persistable/__init__.py
@@ -1,2 +1,4 @@
 from .base import Persistable  # noqa
 from .data import PersistableParams  # noqa
+
+__version__ = "1.2.0"

--- a/persistable/exceptions.py
+++ b/persistable/exceptions.py
@@ -3,5 +3,9 @@ class ExplainedNotImplementedError(NotImplementedError):
         super().__init__(f"{self.__class__.__name__}.{method_name} not implemented")
 
 
-class NoPayloadError(Exception):
-    ...
+PayloadError = type("PayloadError", (Exception,), {})
+NoPayloadError = type("NoPayloadError", (PayloadError,), {})
+InvalidPayloadError = type("InvalidPayloadError", (PayloadError,), {})
+
+
+InvalidPayloadWarning = type("InvalidPayloadWarning", (Warning,), {})

--- a/persistable/exceptions.py
+++ b/persistable/exceptions.py
@@ -1,3 +1,7 @@
 class ExplainedNotImplementedError(NotImplementedError):
     def __init__(self, method_name: str) -> None:
         super().__init__(f"{self.__class__.__name__}.{method_name} not implemented")
+
+
+class NoPayloadError(Exception):
+    ...

--- a/setup.py
+++ b/setup.py
@@ -17,10 +17,10 @@ dev_requires: List[str] = [
 
 setup(
     name="persistable",
-    version="1.1.0",
+    version="1.2.0",
     packages=find_packages(),
     url="https://github.com/aloosley/persistable",
-    download_url="https://github.com/aloosley/persistable/archive/1.1.0.tar.gz",
+    download_url="https://github.com/aloosley/persistable/archive/1.2.0.tar.gz",
     license="",
     author="Alex Loosley, Stephan Sahm",
     author_email="aloosley@alumni.brown.edu, Stephan.Sahm@gmx.de",


### PR DESCRIPTION
Interface for defining runtime payload validation checks.

For example, this is sometimes useful if the underlying data generation mechanism is changing.  Such a check can help users get a tip when loaded payloads are now out-of-date (invalid) and should be regenerated.