### PR TITLE
Params tree bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![](https://img.shields.io/badge/version-1.2.0-green.svg)
+![](https://img.shields.io/badge/version-1.2.1-green.svg)
 [![Build & Test](https://github.com/aloosley/persistable/actions/workflows/python-build.yml/badge.svg)](https://github.com/aloosley/persistable/actions/workflows/python-build.yml)
 [![contributions welcome](https://img.shields.io/badge/contributions-welcome-brightgreen.svg?style=flat)](https://github.com/dwyl/esta/issues)
 

--- a/persistable/__init__.py
+++ b/persistable/__init__.py
@@ -1,4 +1,4 @@
 from .base import Persistable  # noqa
 from .data import PersistableParams  # noqa
 
-__version__ = "1.2.0"
+__version__ = "1.2.1"

--- a/persistable/base.py
+++ b/persistable/base.py
@@ -101,7 +101,7 @@ class Persistable(Generic[PayloadTypeT, PersistableParamsT]):
     @property
     def params_tree(self) -> Dict[str, Any]:
         return self.params.to_dict() | {
-            persistable_obj.payload_name: persistable_obj.params.to_dict()
+            persistable_obj.payload_name: persistable_obj.params_tree
             for persistable_obj in self.tracked_persistable_dependencies
         }
 

--- a/setup.py
+++ b/setup.py
@@ -17,10 +17,10 @@ dev_requires: List[str] = [
 
 setup(
     name="persistable",
-    version="1.2.0",
+    version="1.2.1",
     packages=find_packages(),
     url="https://github.com/aloosley/persistable",
-    download_url="https://github.com/aloosley/persistable/archive/1.2.0.tar.gz",
+    download_url="https://github.com/aloosley/persistable/archive/1.2.1.tar.gz",
     license="",
     author="Alex Loosley, Stephan Sahm",
     author_email="aloosley@alumni.brown.edu, Stephan.Sahm@gmx.de",


### PR DESCRIPTION
The persistable object property `params_tree` is expected to return a tree of parameters for the persistable instance, it's `tracked_persistable_dependencies`, their `tracked_persistable_dependencies`, and so on.  However, the current behaviour does not go more than one level deep.  This is a bug.

This PR addresses the bug by having calls to `params_tree` recursively call `params_tree` for each persistable instance in `tracked_persistable_dependencies`.