### PR TITLE
Separate Hashing from Persist-Filepath Function

### DIFF
--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -19,8 +19,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-18.04, ubuntu-20.04]
-        python: [3.9.13, 3.10.4]
+        os: [windows-latest, ubuntu-latest]
+        python: [3.11.11, 3.13.0]
     steps:
     - name: Checkout
       uses: actions/checkout@v3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ default_stages: [commit]
 fail_fast: true
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v5.0.0
     hooks:
     -   id: check-yaml
     -   id: check-json
@@ -15,7 +15,7 @@ repos:
         files: ^.ipynb
     -   id: trailing-whitespace
 -   repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 24.10.0
     hooks:
     -   id: black
 -   repo: https://github.com/pycqa/flake8
@@ -23,7 +23,7 @@ repos:
     hooks:
     -   id: flake8
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.961
+    rev: v1.13.0
     hooks:
     -   id: mypy
         name: mypy --strict

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,8 +18,8 @@ repos:
     rev: 22.3.0
     hooks:
     -   id: black
--   repo: https://gitlab.com/pycqa/flake8
-    rev: 4.0.1
+-   repo: https://github.com/pycqa/flake8
+    rev: 7.1.1
     hooks:
     -   id: flake8
 -   repo: https://github.com/pre-commit/mirrors-mypy

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![](https://img.shields.io/badge/version-1.2.2-green.svg)
+![](https://img.shields.io/badge/version-1.2.3-green.svg)
 [![Build & Test](https://github.com/aloosley/persistable/actions/workflows/python-build.yml/badge.svg)](https://github.com/aloosley/persistable/actions/workflows/python-build.yml)
 [![contributions welcome](https://img.shields.io/badge/contributions-welcome-brightgreen.svg?style=flat)](https://github.com/dwyl/esta/issues)
 

--- a/persistable/__init__.py
+++ b/persistable/__init__.py
@@ -1,4 +1,4 @@
 from .base import Persistable  # noqa
 from .data import PersistableParams  # noqa
 
-__version__ = "1.2.2"
+__version__ = "1.2.3"

--- a/persistable/base.py
+++ b/persistable/base.py
@@ -132,7 +132,6 @@ class Persistable(Generic[PayloadTypeT, PersistableParamsT]):
             self.persist()
 
     def persist(self) -> None:
-
         """Persist both payload and parameters."""
 
         if self._payload is None:
@@ -274,5 +273,8 @@ class Persistable(Generic[PayloadTypeT, PersistableParamsT]):
 
     @property
     def persist_filepath(self) -> Path:
-        params_tree_hex = md5(str({self.payload_name: self.params_tree}).encode()).hexdigest()
-        return self.data_dir / f"{self.payload_name}({params_tree_hex})"
+        return self.data_dir / f"{self.payload_name}({self.persist_hash})"
+
+    @property
+    def persist_hash(self) -> str:
+        return md5(str({self.payload_name: self.params_tree}).encode()).hexdigest()

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     version="1.2.2",
     packages=find_packages(),
     url="https://github.com/aloosley/persistable",
-    download_url="https://github.com/aloosley/persistable/archive/1.2.2.tar.gz",
+    download_url="https://github.com/aloosley/persistable/archive/1.2.3.tar.gz",
     license="",
     author="Alex Loosley, Stephan Sahm",
     author_email="aloosley@alumni.brown.edu, Stephan.Sahm@gmx.de",

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ dev_requires: List[str] = [
 
 setup(
     name="persistable",
-    version="1.2.2",
+    version="1.2.3",
     packages=find_packages(),
     url="https://github.com/aloosley/persistable",
     download_url="https://github.com/aloosley/persistable/archive/1.2.3.tar.gz",

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -118,6 +118,7 @@ class TestPersistable:
 
         # WHEN and THEN
         assert dummy_persistable.params_tree == params.to_dict()
+        assert dummy_persistable.persist_hash == "6a0f2e637a47f02428f19726be8541a1"
         assert dummy_persistable.persist_filepath == data_dir / "dummy_persistable(6a0f2e637a47f02428f19726be8541a1)"
 
         # WHEN payload_name changed
@@ -125,6 +126,7 @@ class TestPersistable:
 
         # THEN persist filepath has changed (hash should be determined from params_tree and payload_name)
         assert dummy_persistable.params_tree == params.to_dict()
+        assert dummy_persistable.persist_hash == "e15cab0e04c56c6deddb1ac7bc5e5956"
         assert dummy_persistable.persist_filepath == data_dir / "another(e15cab0e04c56c6deddb1ac7bc5e5956)"
 
         # WHEN params changed
@@ -132,6 +134,7 @@ class TestPersistable:
 
         # THEN persist filepath has changed (hash should be determined from params_tree and payload_name)
         assert dummy_persistable.params_tree == params.to_dict()
+        assert dummy_persistable.persist_hash == "bd9f250dac257114768e128ed4d9eb96"
         assert dummy_persistable.persist_filepath == data_dir / "another(bd9f250dac257114768e128ed4d9eb96)"
 
         # WHEN the tracked persistable dependencies change
@@ -142,6 +145,7 @@ class TestPersistable:
         assert dummy_persistable.params_tree == params.to_dict() | {
             dummy_persistable_2.payload_name: params_2.to_dict()
         }
+        assert dummy_persistable.persist_hash == "e1815602bc39616f5378f6305ef2d8ee"
         assert dummy_persistable.persist_filepath == data_dir / "another(e1815602bc39616f5378f6305ef2d8ee)"
 
     def test_multilevel_params_tree(self, tmp_path: Path) -> None:

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -105,7 +105,7 @@ class TestPersistable:
             a=1, b="hello", dummy_persistable=dict(a=1, b="hello")
         )
 
-    def test_persist_filepath_determined_by_both_params_tree_and_payload_name(self, tmp_path: Path) -> None:
+    def test_persist_hash_and_filepath_determined_by_both_params_tree_and_payload_name(self, tmp_path: Path) -> None:
         # GIVEN some persistable instances
         data_dir = tmp_path
         params = DummyPersistableParams()
@@ -116,10 +116,12 @@ class TestPersistable:
             data_dir=data_dir, params=params_2, tracked_persistable_dependencies=None
         )
 
-        # WHEN and THEN
+        initial_expected_hash = "6a0f2e637a47f02428f19726be8541a1"
+
+        # THEN
         assert dummy_persistable.params_tree == params.to_dict()
-        assert dummy_persistable.persist_hash == "6a0f2e637a47f02428f19726be8541a1"
-        assert dummy_persistable.persist_filepath == data_dir / "dummy_persistable(6a0f2e637a47f02428f19726be8541a1)"
+        assert dummy_persistable.persist_hash == initial_expected_hash
+        assert dummy_persistable.persist_filepath == data_dir / f"dummy_persistable({initial_expected_hash})"
 
         # WHEN payload_name changed
         dummy_persistable.payload_name = "another"
@@ -147,6 +149,26 @@ class TestPersistable:
         }
         assert dummy_persistable.persist_hash == "e1815602bc39616f5378f6305ef2d8ee"
         assert dummy_persistable.persist_filepath == data_dir / "another(e1815602bc39616f5378f6305ef2d8ee)"
+        assert dummy_persistable.persist_hash == "e1815602bc39616f5378f6305ef2d8ee"
+
+        # WHEN the params and persistable name are returned to their original values
+        dummy_persistable.payload_name = "dummy_persistable"
+        dummy_persistable.params = DummyPersistableParams()
+        dummy_persistable.tracked_persistable_dependencies = []
+
+        # THEN the hash and filepath do as well
+        assert dummy_persistable.persist_hash == initial_expected_hash
+        assert dummy_persistable.persist_filepath == data_dir / f"dummy_persistable({initial_expected_hash})"
+
+        # WHEN a new persistable is created
+        params = DummyPersistableParams()
+        new_dummy_persistable = DummyPersistable(
+            data_dir=data_dir, params=params, tracked_persistable_dependencies=None
+        )
+
+        # THEN the has is still the same as above
+        assert new_dummy_persistable.persist_hash == initial_expected_hash
+        assert new_dummy_persistable.persist_filepath == data_dir / f"dummy_persistable({initial_expected_hash})"
 
     def test_multilevel_params_tree(self, tmp_path: Path) -> None:
         # GIVEN some persistable instances that depend on each other
@@ -194,7 +216,7 @@ class TestPersistable:
             dummy_persistable.validate_payload()
         dummy_persistable.validate_payload(payload=valid_payload)
         with pytest.raises(InvalidPayloadError):
-            dummy_persistable.validate_payload(payload=invalid_payload)
+            dummy_persistable.validate_payload(payload=invalid_payload)  # type: ignore
 
     def test_validate_payload_on_load(self, tmp_path: Path) -> None:
         # GIVEN persistable


### PR DESCRIPTION
Changes
* [x] The hashing function that created the persist filepath has now been moved to it's own function
* [x] Extra hash testing to ensure determinism 

Also included:
* [x] Updates to pre-commit hooks, including to flake8 hook which was broken